### PR TITLE
exempt service call from using json

### DIFF
--- a/internal/mcp/context.go
+++ b/internal/mcp/context.go
@@ -134,7 +134,7 @@ func resolveServiceReferences(flags []Flag) []Flag {
 
 func applySmartDefaults(cmd string, args []string, flags []Flag) []Flag {
 	// Add JSON output for list commands if not specified
-	if len(args) > 0 && args[0] == "list" && !hasFlag(flags, "json") {
+	if len(args) > 0 && args[0] == "list" && cmd != "service" && !hasFlag(flags, "json") {
 		if globalContext.PreferredFormat == "json" || globalContext.PreferredFormat == "" {
 			flags = append(flags, Flag{Name: "json", Value: ""})
 		}

--- a/internal/mcp/context_test.go
+++ b/internal/mcp/context_test.go
@@ -316,13 +316,24 @@ func TestApplySmartDefaults(t *testing.T) {
 			},
 		},
 		{
-			name:       "adds json flag for list commands",
-			cmd:        "service",
+			name:       "adds json flag for non-service list commands",
+			cmd:        "kv-store",
 			args:       []string{"list"},
 			inputFlags: []Flag{},
 			checkFunc: func(t *testing.T, flags []Flag) {
 				if !hasFlag(flags, "json") {
 					t.Error("Expected json flag to be added for list command")
+				}
+			},
+		},
+		{
+			name:       "does not add json flag for service list commands",
+			cmd:        "service",
+			args:       []string{"list"},
+			inputFlags: []Flag{},
+			checkFunc: func(t *testing.T, flags []Flag) {
+				if hasFlag(flags, "json") {
+					t.Error("Expected json flag not to be added for service list command")
 				}
 			},
 		},


### PR DESCRIPTION
The `fastly service list --json` command returns a massive amount of unnecessary data, especially when your account has nearly 100 services. 

More specifically, every service includes an array with details on every version its ever had. We have nearly 100 services, some of which have 700+ versions. Our `fastly service list --json` currently returns over 1.15 MB of text, or roughly 448,310 tokens, and that number can only grow. 

This immediately overloads the LLM context for most models and causes the call to fail. 

I've found this fix to work well, as it allows the LLM to truly obtain a simple list of services, then query what's necessary after that. 

Perhaps you could instead intercept the json to remove the excess data before passing it to the LLM, but this seemed like the most straightforward approach. 